### PR TITLE
invoke has_latex

### DIFF
--- a/R/latex.R
+++ b/R/latex.R
@@ -10,7 +10,7 @@ has_latex <- function() {
 #' @export
 #' @rdname has_latex
 check_latex <- function() {
-  if (!has_latex)
+  if (!has_latex())
     stop("LaTeX not installed (pdflatex not found)", call. = FALSE)
 
   TRUE


### PR DESCRIPTION
I don't know if there is some wizardry I'm not aware of where an if statement can take a function to invoke, however I assume this was just a quick mistype.

For sanity I also confirmed that this should error as of now, with the following

```
Error in if (!has_latex): argument is not interpretable as logical
```