### PR TITLE
Pin callr dependency to current version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     rprojroot,
     withr
 Remotes:
-    mangothecat/callr
+    r-pkgs/callr@3609df80
 Suggests:
     Rcpp,
     testthat,


### PR DESCRIPTION
Because callr is about to introduce a
non backward-compatible change.