### PR TITLE
Depend on newer callr version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     rprojroot,
     withr
 Remotes:
-    r-pkgs/callr@3609df80
+    r-pkgs/callr@HEAD
 Suggests:
     Rcpp,
     testthat,

--- a/R/build.r
+++ b/R/build.r
@@ -68,7 +68,7 @@ build <- function(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE
   withr::with_temp_libpaths(
     rcmd_build_tools(
       cmd,
-      c(shQuote(path), args),
+      c(path, args),
       wd = out_dir,
       show = !quiet,
       echo = !quiet,

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -144,8 +144,8 @@ install_min <- function(path = ".", dest, components = NULL, args = NULL, quiet 
   rcmd_build_tools(
     "INSTALL",
     c(
-      shQuote(path),
-      paste("--library=", shQuote(dest), sep = ""),
+      path,
+      paste("--library=", dest, sep = ""),
       no_args,
       "--no-multiarch",
       "--no-test-load",


### PR DESCRIPTION
Newer callr uses processx to run child processes,
and it does not require (it actually forbids) quoting
the program name and arguments.